### PR TITLE
Do not clone single practiceProblems repo into sub directory

### DIFF
--- a/scioer_builder/cli.py
+++ b/scioer_builder/cli.py
@@ -573,7 +573,7 @@ def run(opts, **kwargs):
         exampleRepo.auth = gitAuthentication
         clone_repo(
             exampleRepo,
-            example.split("/")[-1][:-4] if len(opts["example"]) > 1 else '.',
+            example.split("/")[-1][:-4] if len(opts["example"]) > 1 else ".",
             examples,
             keep_git=opts["keep_git"],
         )

--- a/scioer_builder/cli.py
+++ b/scioer_builder/cli.py
@@ -567,12 +567,13 @@ def run(opts, **kwargs):
 
     examples = os.path.join(dir.name, "practiceProblems")
     os.makedirs(examples, exist_ok=True)
+
     for example in opts["example"]:
         exampleRepo = Repository(example, None, True, not opts["no_verify_host"])
         exampleRepo.auth = gitAuthentication
         clone_repo(
             exampleRepo,
-            example.split("/")[-1][:-4],
+            example.split("/")[-1][:-4] if len(opts["example"]) > 1 else '.',
             examples,
             keep_git=opts["keep_git"],
         )


### PR DESCRIPTION
<!-- Tags (fill and keep as many as applicable) -->

Closes: #53

---

**Describe the pull request:**
<!-- This should include a description of the bug/feature and how you solved it -->

When there is only a single practice problem repository provided clone the contents directly into the `/course/practiceProblems` directory instead of `/course/practiceProblems/<repo name>`. 


**This is a breaking change and may cause some content paths to be incorrect**

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.-->
<!-- Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [x] Verify that the changes work as expected
- [x] Verify that the changes work as expected when run using docker
- [x] Update documentation / not applicable
- [x] Update changelog / not applicable
