### PR TITLE
fix: change ownership of the letures directory to be owned by the student user

### DIFF
--- a/builder/data/Dockerfile
+++ b/builder/data/Dockerfile
@@ -18,5 +18,10 @@ COPY practiceProblems /builtin/practiceProblems/
 ADD database.sqlite.tar /opt/wiki/
 #COPY motd.txt /scripts/motd.txt
 
+USER root
+RUN chown -R ${UID}:${UID} /opt/static/lectures /opt/wiki
+USER ${UNAME}
+
+
 ARG BUILD_DATE
 LABEL org.opencontainers.image.created="${BUILD_DATE}"


### PR DESCRIPTION
<!-- Tags (fill and keep as many as applicable) -->

Closes: #110 
---

**Describe the pull request:**
<!-- This should include a description of the bug/feature and how you solved it -->

Changes the ownership of the lectures directory so that when the `--keep-git` flag is used the user can still interact with the git repository.

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.-->
<!-- Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [x] Verify that the changes work as expected
- [ ] Verify that the changes work as expected when run using docker
- [ ] Update documentation / not applicable
- [ ] Update changelog / not applicable
