### PR TITLE
fix: expand ssh key path name before it is used

### DIFF
--- a/builder/cli.py
+++ b/builder/cli.py
@@ -610,7 +610,7 @@ def run(opts, **kwargs):
         )
         sys.exit("Incompatible arguments")
 
-    sshKeyFile = load_ssh_key(opts["key_file"])
+    sshKeyFile = load_ssh_key(os.path.expanduser(opts["key_file"]))
     if sshKeyFile != "":
         sshKeyFile = os.path.realpath(sshKeyFile)
 


### PR DESCRIPTION
<!-- Tags (fill and keep as many as applicable) -->

Closes: #108 
---

**Describe the pull request:**
<!-- This should include a description of the bug/feature and how you solved it -->

Expand the ssh key path before it is used to prevent 'file not found' errors because of the `~` character in the file path. 

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.-->
<!-- Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [ ] Verify that the changes work as expected
- [ ] Verify that the changes work as expected when run using docker
- [ ] Update documentation / not applicable
- [ ] Update changelog / not applicable
