### PR TITLE
fix: no longer crashes if an ssh key file is not specified

### DIFF
--- a/builder/cli.py
+++ b/builder/cli.py
@@ -643,7 +643,7 @@ def run(opts, **kwargs):
         )
         sys.exit("Incompatible arguments")
 
-    sshKeyFile = load_ssh_key(os.path.expanduser(opts["key_file"]))
+    sshKeyFile = load_ssh_key(os.path.expanduser(opts["key_file"] or ""))
     if sshKeyFile != "":
         sshKeyFile = os.path.realpath(sshKeyFile)
 

--- a/builder/cli.py
+++ b/builder/cli.py
@@ -66,7 +66,7 @@ import datetime
 import importlib.resources as pkg_resources
 
 try:
-    from git import Repo  # noqa: I900
+    from git import Repo, GitCommandError  # noqa: I900
 except:
     sys.exit("Can not run, `git` must be installed on the system.")
 
@@ -270,7 +270,9 @@ def clone_repo(repo, name, dir, keep_git=False, **kwargs):
 
     git_ssh_cmd = ""
     if repo.isSSH():
-        git_ssh_cmd = f'ssh {"-o StrictHostKeyChecking=no " if not repo.verify_host else " "}-i {repo.auth.ssh_file}'
+        keyFile = f"-i {repo.auth.ssh_file}" if repo.auth.ssh_file else ""
+        git_ssh_cmd = f'ssh {"-o StrictHostKeyChecking=no " if not repo.verify_host else " "}{keyFile}'
+
     Repo.clone_from(repo.uri, folder, env=dict(GIT_SSH_COMMAND=git_ssh_cmd))
 
     if not keep_git:


### PR DESCRIPTION
<!-- Tags (fill and keep as many as applicable) -->

Closes: #121
Related: # <!-- number of issue/pull request, or link to external discussion -->

---

**Describe the pull request:**
<!-- This should include a description of the bug/feature and how you solved it -->

[insert text here]

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.-->
<!-- Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [ ] Verify that the changes work as expected
- [ ] Verify that the changes work as expected when run using docker
- [ ] Update documentation / not applicable
- [ ] Update changelog / not applicable
