### PR TITLE
fix: removed trailing .CONTAINER that got left behind in the ssh key file path when cleaning up the wiki

### DIFF
--- a/builder/cli.py
+++ b/builder/cli.py
@@ -524,6 +524,7 @@ def configure_wiki_repo(host, enabled, repo, **kwargs):
         }
     }"""
 
+    keyFile = f"{repo.auth.ssh_file}.CONTAINER" if repo.auth.ssh_file else ""
     variables = {
         "targets": [
             {
@@ -544,7 +545,7 @@ def configure_wiki_repo(host, enabled, repo, **kwargs):
                     },
                     {
                         "key": "sshPrivateKeyPath",
-                        "value": f'{{"v": "{repo.auth.ssh_file}.CONTAINER"}}',
+                        "value": f'{{"v": "{keyFile}"}}',
                     },
                     {
                         "key": "sshPrivateKeyContent",


### PR DESCRIPTION
<!-- Tags (fill and keep as many as applicable) -->

Closes: # <!-- number of issue or pull request -->
Related: # <!-- number of issue/pull request, or link to external discussion -->

---

**Describe the pull request:**
<!-- This should include a description of the bug/feature and how you solved it -->

[insert text here]

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.-->
<!-- Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [ ] Verify that the changes work as expected
- [ ] Verify that the changes work as expected when run using docker
- [ ] Update documentation / not applicable
- [ ] Update changelog / not applicable
