### PR TITLE
fix: setuptools in docker image fails to get version number

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -56,8 +56,8 @@ jobs:
       run: |
         current_ver="$(git describe --abbrev=0 --tags | sed 's/v//')"
         new_ver=$(semver bump "${{ github.event.inputs.version }}" "$current_ver")
-        echo "::set-output name=last::${current_ver}"
-        echo "::set-output name=new::${new_ver}"
+        echo "last=${current_ver}" >> $GITHUB_OUTPUT
+        echo "new=${new_ver}" >> $GITHUB_OUTPUT
 
     - name: "Generate release changelog"
       id: generate-changelog

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -37,8 +37,7 @@ jobs:
       - name: Setup the current date
         id: prep
         run: |
-          echo "::set-output name=date::$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
-          echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+          echo "date=$(date -u +'%Y-%m-%dT%H:%M:%SZ')"" >> $GITHUB_OUTPUT
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4
@@ -74,4 +73,4 @@ jobs:
           build-args: |
             BUILD_DATE=${{ steps.date.outputs.date }}
             VCS_REF=${{ github.sha }}
-            VERSION=${{ steps.date.outputs.tag }}
+            VERSION=${{ github.ref_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,8 @@ VOLUME [ "/output" ]
 
 COPY . .
 
-RUN pip install . && rm -rf custom src
+ARG SETUPTOOLS_SCM_PRETEND_VERSION=$VERSION
+RUN pip install . && rm -rf builder
 
 ENTRYPOINT [ "./entrypoint.sh" ]
 


### PR DESCRIPTION
- fix: use fake version in dockerfile for setuptools-scm
- fix: update deprecated syntax in workflow

<!-- Tags (fill and keep as many as applicable) -->

Closes: # <!-- number of issue or pull request -->
Related: # <!-- number of issue/pull request, or link to external discussion -->

---

**Describe the pull request:**
<!-- This should include a description of the bug/feature and how you solved it -->

[insert text here]

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.-->
<!-- Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [ ] Verify that the changes work as expected
- [ ] Verify that the changes work as expected when run using docker
- [ ] Update documentation / not applicable
- [ ] Update changelog / not applicable
