### PR TITLE
fix: add missing docker cli and buildx plugin when running in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,13 @@ WORKDIR /app
 
 VOLUME [ "/output" ]
 
+ENV DOCKERVERSION=20.10.17
+RUN curl -fsSLO https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKERVERSION}.tgz \
+  && tar xzvf docker-${DOCKERVERSION}.tgz --strip 1 \
+                 -C /usr/local/bin docker/docker \
+  && rm docker-${DOCKERVERSION}.tgz
+COPY --from=docker/buildx-bin:latest /buildx /usr/libexec/docker/cli-plugins/docker-buildx
+
 COPY . .
 
 ARG SETUPTOOLS_SCM_PRETEND_VERSION=$VERSION

--- a/builder/cli.py
+++ b/builder/cli.py
@@ -63,7 +63,7 @@ import sys
 import tempfile
 from dataclasses import dataclass
 from time import sleep
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 import colorlog
 import docker
@@ -428,7 +428,7 @@ def build_multi_arch(
     cleanup_buildx(old_builder, builder_name)
 
 
-def setup_buildx() -> tuple:
+def setup_buildx() -> Tuple[str, str]:
     res = subprocess.run(
         "docker buildx inspect", shell=True, check=True, capture_output=True
     )


### PR DESCRIPTION
<!-- Tags (fill and keep as many as applicable) -->

Closes: #123
---

**Describe the pull request:**
<!-- This should include a description of the bug/feature and how you solved it -->

The docker image did not include the docker cli client or thr buildx plugin which are called directly when building multi architecture images.

This adds both binaries to the image and will setup a new buildx builder for the lifetime of the command.

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.-->
<!-- Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [ ] Verify that the changes work as expected
- [ ] Verify that the changes work as expected when run using docker
- [ ] Update documentation / not applicable
- [ ] Update changelog / not applicable
