### PR TITLE
fix: add meaningful information to the error message when the wiki fails to sync

### DIFF
--- a/builder/cli.py
+++ b/builder/cli.py
@@ -530,8 +530,12 @@ def sync_wiki_repo(host: str, **kwargs) -> None:
     _LOGGER.warning(
         "Syncing all the wiki content from the git repository, this may take a while..."
     )  # noqa: E501
-    api_call(host, query, **kwargs)
-    _LOGGER.warning("Done syncing wiki content")
+    try:
+        api_call(host, query, **kwargs)
+        _LOGGER.warning("Done syncing wiki content")
+    except:
+        error_message = get_wiki_storage_status(host, **kwargs)
+        raise Exception(f"Failed to import the wiki: ${error_message}")
 
 
 def import_wiki_repo(host: str, **kwargs):
@@ -546,8 +550,29 @@ def import_wiki_repo(host: str, **kwargs):
     _LOGGER.warning(
         "Importing all the wiki content from the git repository, this may take a while..."
     )  # noqa: E501
-    api_call(host, query, **kwargs)
-    _LOGGER.warning("Done importing wiki content")
+    try:
+        api_call(host, query, **kwargs)
+        _LOGGER.warning("Done importing wiki content")
+    except:
+        error_message = get_wiki_storage_status(host, **kwargs)
+        raise Exception(f"Failed to import the wiki: ${error_message}")
+
+
+def get_wiki_storage_status(host: str, **kwargs) -> str:
+    query = """{
+        storage {
+            status {
+            key
+            status
+            message
+            }
+        }
+    }"""
+
+    _LOGGER.info("Getting the status of the wiki storage...")  # noqa: E501
+    message = api_call(host, query, **kwargs)
+    _LOGGER.info("Done fetching the wiki status")
+    return message
 
 
 def set_wiki_comments(host: str, enabled: bool, **kwargs):
@@ -700,7 +725,7 @@ def dissable_api(host: str, **kwargs) -> None:
     api_call(host, query, **kwargs)
 
 
-def api_call(host: str, query: str, variables: dict = {}, port: int = 3000) -> None:
+def api_call(host: str, query: str, variables: dict = {}, port: int = 3000) -> str:
     headers = {"Authorization": f"Bearer {API_TOKEN}"}
 
     body = {"query": query, "variables": variables}
@@ -708,12 +733,19 @@ def api_call(host: str, query: str, variables: dict = {}, port: int = 3000) -> N
     r = requests.post(f"http://{host}:{port}/graphql", json=body, headers=headers)
 
     payload = r.json()
-    payload = payload["data"][list(payload["data"].keys())[0]]
-    succeeded = payload[list(payload.keys())[0]]["responseResult"]["succeeded"]
-    message = payload[list(payload.keys())[0]]["responseResult"]["message"]
+
+    if "responseResult" in query:
+        payload = payload["data"][list(payload["data"].keys())[0]]
+        succeeded = payload[list(payload.keys())[0]]["responseResult"]["succeeded"]
+        message = payload[list(payload.keys())[0]]["responseResult"]["message"]
+    else:
+        payload = payload["data"][list(payload["data"].keys())[0]]
+        succeeded = True
+        message = payload[list(payload.keys())[0]][0]["message"]
 
     if r.status_code == 200 and succeeded:
-        _LOGGER.info(message or "API call was successful")
+        _LOGGER.debug(message or "API call was successful")
+        return message
     else:
         _LOGGER.error(json.dumps(r.json(), indent=2))
         raise Exception(f"Query failed to run with a {r.status_code}.")


### PR DESCRIPTION
<!-- Tags (fill and keep as many as applicable) -->

Closes: # <!-- number of issue or pull request -->
Related: # <!-- number of issue/pull request, or link to external discussion -->

---

**Describe the pull request:**
<!-- This should include a description of the bug/feature and how you solved it -->

Currently when the wiki fails to sync (typically because of issues with the ssh key
the only error message that is given looks like there is an issue with the branch name. 


This PR will add an extra call after the sync fails that will get the real reason why the
wiki git repository failed to sync.

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.-->
<!-- Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [ ] Verify that the changes work as expected
- [ ] Verify that the changes work as expected when run using docker
- [ ] Update documentation / not applicable
- [ ] Update changelog / not applicable
